### PR TITLE
Allow more recent versions of pyTMD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ REQUIRED = [
     "pyarrow",
     "pydantic",
     "pyproj",
-    "pyTMD==2.1.4",
+    "pyTMD>=2.1.4",
     "python_geohash",
     "pytz",
     "PyYAML",


### PR DESCRIPTION
Closes #3 

I don't have an environment (yet) to test whether there are any implications, sorry.