### PR TITLE
Update coastlines with tide model name

### DIFF
--- a/coastlines/combined.py
+++ b/coastlines/combined.py
@@ -641,7 +641,7 @@ def process_coastlines(
     # Calculate tides and combine with the data
     log.info("Filtering by tides")
     n_times = len(data.time)
-    data = filter_by_tides(data, tide_data_location, config.options.tide_centre)
+    data = filter_by_tides(data, tide_data_location, config.options.tide_centre, config.options.tide_model)
     log.info(
         f"Dropped {n_times - len(data.time)} out of {n_times} timesteps due to extreme tides"
     )
@@ -651,7 +651,7 @@ def process_coastlines(
         data = data.compute()
 
     log.info("Running per-pixel tide masking at high resolution")
-    data = mask_pixels_by_tide(data, tide_data_location, config.options.tide_centre)
+    data = mask_pixels_by_tide(data, tide_data_location, config.options.tide_centre, config.options.tide_model)
 
     if config.options.mask_with_hillshade:
         log.info("Running per-pixel terrain shadow masking")

--- a/configs/indonesia_coastlines_config.yaml
+++ b/configs/indonesia_coastlines_config.yaml
@@ -19,6 +19,8 @@ options:
   end_year: 2023
   baseline_year: 2021
 
+  tide_model: FES2022
+
   water_index: "mndwi_nir"
   index_threshold: 0.65
 


### PR DESCRIPTION
Coastlines can now specify the tide model within the config and have it pass through to the relevant functions.